### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.6
+
+WORKDIR /musicscan
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt
+
+COPY musicscan ./musicscan
+COPY musicscan-cli .
+
+WORKDIR /musicscan/run
+
+ENTRYPOINT [ "../musicscan-cli" ]


### PR DESCRIPTION
Adds a very simple dockerfile. Users can mount torrent/music directories and supply extra arguments to configure it.

Also, the workdir is set to /musicscan/run, so that you can mount it somewhere easily to keep the log and state files.

Example usage:

```
docker run -d --name='musicscan' \
  -v '/mnt/user/music/':'/music':'ro' \
  -v '/mnt/user/torrents':'/torrents':'rw' \
  -v '/mnt/user/appdata/musicscan':'/musicscan/run':'rw' \
    'macropower/musicscan:0.1.2' \
      -u <username> \
      -p <password> \
      --loglevel debug \
      --output /torrents \
      /music
```