### PR TITLE
Add wheel as dependency for whatapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+wheel
 mutagen==1.40.0
 python-dateutil==2.6.1
 colorama


### PR DESCRIPTION
Using ubuntu subsystem, `wheel` is not a part of the latest python3 installed. This makes whatapi silently fail.

```
  Building wheel for whatapi (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/mario/bin/musicscan/.venv/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-ihwk5twd/whatapi/setup.py'"'"'; __file__='"'"'/tmp/pip-install-ihwk5twd/whatapi/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-3oa33tdu
       cwd: /tmp/pip-install-ihwk5twd/whatapi/
  Complete output (6 lines):
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help

  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for whatapi
  Running setup.py clean for whatapi
Failed to build mutagen whatapi
```

Placing `wheel` at the top of the requirements file makes building succeed.